### PR TITLE
06_메시지와 인터페이스 첫번째 PR - 명령 - 쿼리 분리 원칙 코드예시

### DIFF
--- a/src/main/java/com/book_review/chap_06_message_interface/Event.java
+++ b/src/main/java/com/book_review/chap_06_message_interface/Event.java
@@ -1,0 +1,37 @@
+package com.book_review.chap_06_message_interface;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class Event {
+
+    private String subject;
+    private LocalDateTime from;
+    private Duration duration;
+
+    public Event(String subject, LocalDateTime from, Duration duration) {
+        this.subject = subject;
+        this.from = from;
+        this.duration = duration;
+    }
+
+    public boolean isSatisfied(RecurringSchedule schedule) {
+        if (from.getDayOfWeek() != schedule.getDayOfWeek() ||
+            !from.toLocalTime().equals(schedule.getFrom()) ||
+            !duration.equals(schedule.getDuration())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public void reschedule(RecurringSchedule schedule) {
+        from = LocalDateTime.of(from.toLocalDate().plusDays(daysDistance(schedule)),
+                schedule.getFrom());
+        duration = schedule.getDuration();
+    }
+
+    private long daysDistance(RecurringSchedule schedule) {
+        return schedule.getDayOfWeek().getValue() - from.getDayOfWeek().getValue();
+    }
+}

--- a/src/main/java/com/book_review/chap_06_message_interface/Main.java
+++ b/src/main/java/com/book_review/chap_06_message_interface/Main.java
@@ -1,0 +1,23 @@
+package com.book_review.chap_06_message_interface;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class Main {
+    public static void main(String[] args) {
+        Event meeting = new Event("회의",
+                LocalDateTime.of(2019, 5, 8, 10, 30),
+                Duration.ofMinutes(30));
+
+        RecurringSchedule schedule = new RecurringSchedule("회의", DayOfWeek.WEDNESDAY,
+                LocalTime.of(10,30), Duration.ofMillis(30));
+
+        assert meeting.isSatisfied(schedule) == false;
+
+        if (!meeting.isSatisfied(schedule)) {
+            meeting.reschedule(schedule);
+        }
+    }
+}

--- a/src/main/java/com/book_review/chap_06_message_interface/RecurringSchedule.java
+++ b/src/main/java/com/book_review/chap_06_message_interface/RecurringSchedule.java
@@ -1,0 +1,32 @@
+package com.book_review.chap_06_message_interface;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalTime;
+
+public class RecurringSchedule {
+
+    private String subject;
+    private DayOfWeek dayOfWeek;
+    private LocalTime from;
+    private Duration duration;
+
+    public RecurringSchedule(String subject, DayOfWeek dayOfWeek, LocalTime from, Duration duration) {
+        this.subject = subject;
+        this.dayOfWeek = dayOfWeek;
+        this.from = from;
+        this.duration = duration;
+    }
+
+    public DayOfWeek getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public LocalTime getFrom() {
+        return from;
+    }
+
+    public Duration getDuration() {
+        return duration;
+    }
+}


### PR DESCRIPTION
`06_메시지와 인터페이스`의 첫 번째 PR로 반복 일정과 관련된 애플리케이션을 구현하였다.

---
#####  1. 개요
- 특정 단발성 이벤트 역할을 담당하는 `Event`와 반복일정 관리의 역할을 담당하는 `RecurringSchedule` 클래스를 생성하였다.
- 명령 - 쿼리 분리의 원칙을 따르지 않고 두가지 클래스를 구현하고 사용하는 페이지에서 `assert meeting.isSatisfied(schedule) == false;`를 실행할 경우 최초에는 `false`를 반환하지만, 두 번째 이후에는 `true`를 반환하는 구조였다.
  - 원인은 `Event` 클래스의 `isSatisfied()` 함수 내부에서 명령과 쿼리의 역할이 동시에 실행되고 있었다.
  - ```
    public boolean isSatisfied(RecurringSchedule schedule) {
      ...
      reschedule(schedule);
      ...
    }

    private void reschedule(RecurringSchedule schedule) {
      ...
    }
    ```
  - 위 구조처럼 쿼리를 수행하는 `isSatisfied()`내부에  명령을 수행하는 `reschedule()`이 포함되어 있어 구조적 문제가 발생한다.
- 명령 - 쿼리 분리 원칙을 준수하기 위해 `isSatisfied()` 내부에 명령을 수행하는 `reschedule()`을 제외하고 reschedule()은 접근 제어자를 `private` 에서 `public`으로 수정하였다.

---
##### 2. 결론
- 명령과 쿼리가 결합되어 있던 구조를 분리하여 코드 리딩에서도 각 메서드가 어떠한 역할을 수행하는지 명시적으로 확인할 수 있고, 구조적 문제를 발생하지 않도록 수정할 수 있었다.
